### PR TITLE
Checking the master name before reconnecting all clients.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,18 @@ Sentinel.prototype.createClient = function(masterName, opts) {
                 console.error("Unable to subscribe to Sentinel PUBSUB");
             }
         });
-        pubsubClient.on("message", function(channel, message) {
-            console.warn("Received +switch-master message from Redis Sentinel.",
-                         " Reconnecting clients.");
-            self.reconnectAllClients();
-        });
+      pubsubClient.on("message", function (channel, message) {
+          var failedOverMaster = message.split(" ")[0];
+          console.warn("Received +switch-master message from Redis Sentinel for master", failedOverMaster);
+          if (failedOverMaster === masterName) {
+              console.warn("Reconnecting clients.");
+              self.reconnectAllClients();
+          }
+          else {
+              console.warn("Ignoring the message");
+          }
+
+      });
         pubsubClient.on("error", function(error) {});
         self.pubsub.push(pubsubClient);
     }


### PR DESCRIPTION

https://zendesk.atlassian.net/browse/INFR-3411
@zendesk/radar 

Now when unrelated redis master flips we ignore the message:
```
app2/runit_radar_1_8002.log-20170329:2017-03-29T17:30:53+00:00 app2 radar_1_8002: Received +switch-master message from Redis Sentinel for master razor-100-1
app2/runit_radar_1_8002.log-20170329-2017-03-29T17:30:53+00:00 app2 radar_1_8002: Ignoring the message
```
When the actual redis master flips, we reconnect:
```
app2/runit_radar_1_8002.log-20170329:2017-03-29T17:31:37+00:00 app2 radar_1_8002: Received +switch-master message from Redis Sentinel for master radar-100-1
app2/runit_radar_1_8002.log-20170329-2017-03-29T17:31:37+00:00 app2 radar_1_8002: Reconnecting clients.
```
