### PR TITLE
Update redis client

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "redis"
   ],
   "dependencies": {
-    "redis": "0.12.x",
-    "when": "^3.5.1",
-    "minilog": "*"
+    "minilog": "*",
+    "redis": "^2.8.0",
+    "when": "^3.5.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
The Redis client is quite old, this PR is supposed to pump the client to the latest version.

@zendesk/radar 